### PR TITLE
GO-13710 Pass height as prop to the action sheet

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -75,9 +75,10 @@ class ActionSheet extends Component {
 		let height = buttonHight * count + cancelMargin
 		if (props.title) height += titleHeight
     if (props.message) height += MESSAGE_H
-		if (height > MAX_HEIGHT) {
+    const maxHeight = props.height ? props.height * 0.7 : MAX_HEIGHT;
+		if (height > maxHeight) {
 			this.scrollEnabled = true;
-			return MAX_HEIGHT
+			return maxHeight
 		} else {
 			this.scrollEnabled = false;
 			return height


### PR DESCRIPTION
When the orientation is changed to landscape, height of the modal is not
getting updated in the library. Therefore, passing the height prop to
the action sheet.